### PR TITLE
Polish the original weather interface

### DIFF
--- a/cypress/e2e/weather.cy.js
+++ b/cypress/e2e/weather.cy.js
@@ -7,6 +7,7 @@ describe("A City's Weather", () => {
     cy.get("#weatherCity").should("have.attr", "aria-label", "Weather search");
     cy.get("#city").should("have.attr", "placeholder", "Enter a City");
     cy.get("#weather_button").should("have.text", "Get Weather");
+    cy.get("#motion-toggle").should("have.text", "Pause motion");
     cy.get(".cloud").should("have.length", 6);
     cy.get("#removed").should("contain.text", "No previous searches");
   });
@@ -26,6 +27,7 @@ describe("A City's Weather", () => {
     cy.get(".tempertures").should("have.length", 3).and("be.visible");
     cy.get("#list").should("contain.text", "Melbourne");
     cy.get(".cloud").should("have.css", "background-image").and("include", "partly-cloudy.png");
+    cy.get(".weather-emoji").should("have.length", 5);
   });
 
   it("toggles units and reuses cached search history", () => {
@@ -55,5 +57,64 @@ describe("A City's Weather", () => {
     cy.get("#cityName").should("have.text", "City Invalid");
     cy.get("#weather_button").should("not.be.disabled").and("have.text", "Get Weather");
     cy.get("#temps").should("not.be.visible");
+  });
+
+  it("pauses and resumes the animated weather layers", () => {
+    cy.get("#motion-toggle").click();
+
+    cy.get("body").should("have.class", "motion-paused");
+    cy.get("#motion-toggle").should("have.text", "Play motion").and("have.attr", "aria-pressed", "true");
+    cy.get(".cloud").should("have.css", "animation-play-state", "paused");
+
+    cy.get("#motion-toggle").click();
+    cy.get("body").should("not.have.class", "motion-paused");
+    cy.get("#motion-toggle").should("have.text", "Pause motion").and("have.attr", "aria-pressed", "false");
+  });
+
+  it("keeps the desktop weather composition intact", () => {
+    cy.viewport(1440, 900);
+    cy.intercept("GET", "https://wttr.in/Melbourne?format=j1", {
+      fixture: "melbourne.json",
+    }).as("desktopWeather");
+
+    cy.get("#city").type("Melbourne").type("{enter}");
+    cy.wait("@desktopWeather");
+
+    cy.window().then((window) => {
+      expect(window.document.documentElement.scrollWidth).to.be.at.most(window.innerWidth);
+    });
+    cy.get("#cityInfo").then(($city) => {
+      cy.get(".mainPage > aside:last-child").then(($history) => {
+        expect($city[0].getBoundingClientRect().right).to.be.lessThan($history[0].getBoundingClientRect().left);
+      });
+    });
+    cy.get(".tempertures").should("have.length", 3).and("be.visible");
+    cy.get(".weather-footer").should("have.css", "position", "fixed");
+  });
+
+  it("stacks the weather experience cleanly on phones", () => {
+    cy.viewport(390, 844);
+    cy.intercept("GET", "https://wttr.in/Melbourne?format=j1", {
+      fixture: "melbourne.json",
+    }).as("mobileWeather");
+
+    cy.get("#city").type("Melbourne").type("{enter}");
+    cy.wait("@mobileWeather");
+
+    cy.window().then((window) => {
+      expect(window.document.documentElement.scrollWidth).to.be.at.most(window.innerWidth);
+      const city = window.document.querySelector("#cityInfo").getBoundingClientRect();
+      expect(city.left).to.be.at.least(0);
+      expect(city.right).to.be.at.most(window.innerWidth);
+    });
+    cy.get("#temps").then(($forecast) => {
+      cy.get(".mainPage > aside:last-child").then(($history) => {
+        expect($history[0].getBoundingClientRect().top).to.be.at.least($forecast[0].getBoundingClientRect().bottom);
+      });
+      cy.get(".weather-footer").then(($footer) => {
+        expect($footer[0].getBoundingClientRect().top).to.be.at.least($forecast[0].getBoundingClientRect().bottom);
+      });
+    });
+    cy.get(".weather-footer").should("have.css", "position", "static");
   });
 });

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <form id="weatherCity" aria-label="Weather search">
             <input id="city" type="text" placeholder="Enter a City" aria-label="City" autocomplete="off">
             <button id="weather_button" type="submit">Get Weather</button>
+            <button id="motion-toggle" type="button" aria-pressed="false">Pause motion</button>
         </form>
     </header>
     <div class="cloud-container">

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const cityInfo = document.querySelector("#cityInfo");
 const temperatures = document.querySelector("#temps");
 const emptyHistory = document.querySelector("#removed");
 const searchHistory = document.querySelector("#list");
+const cloudContainer = document.querySelector(".cloud-container");
 const clouds = document.querySelectorAll(".cloud");
 const days = document.querySelectorAll(".days");
 const averages = document.querySelectorAll(".avg");
@@ -179,7 +180,35 @@ function createHeart() {
   return svg;
 }
 
-async function updateWeatherBackground(weatherCode, city) {
+function weatherEmojis(description) {
+  const condition = description.toLowerCase();
+  if (condition.includes("thunder")) return ["⛈️", "⚡", "🌧️", "⚡", "☁️"];
+  if (condition.includes("snow") || condition.includes("blizzard")) return ["❄️", "🌨️", "❄️", "☁️", "❄️"];
+  if (condition.includes("ice") || condition.includes("freez") || condition.includes("sleet")) {
+    return ["🧊", "🌨️", "❄️", "🧊", "☁️"];
+  }
+  if (condition.includes("rain") || condition.includes("drizzle") || condition.includes("shower")) {
+    return ["🌧️", "💧", "☁️", "💧", "🌦️"];
+  }
+  if (condition.includes("fog") || condition.includes("mist")) return ["🌫️", "☁️", "🌫️", "☁️", "🌫️"];
+  if (condition.includes("cloud") || condition.includes("overcast")) return ["🌤️", "☁️", "🌥️", "☁️", "🌤️"];
+  return ["☀️", "✨", "🌤️", "✨", "☀️"];
+}
+
+function renderWeatherEmojis(description) {
+  cloudContainer.querySelectorAll(".weather-emoji").forEach((emoji) => emoji.remove());
+  weatherEmojis(description).forEach((symbol, index) => {
+    const emoji = document.createElement("span");
+    emoji.className = "weather-emoji";
+    emoji.setAttribute("aria-hidden", "true");
+    emoji.style.setProperty("--weather-layer", String(index + 1));
+    emoji.textContent = symbol;
+    cloudContainer.append(emoji);
+  });
+}
+
+async function updateWeatherBackground(weatherCode, city, description) {
+  renderWeatherEmojis(description);
   try {
     if (!state.weatherIcons) {
       const response = await fetch("icons.json");
@@ -187,9 +216,10 @@ async function updateWeatherBackground(weatherCode, city) {
       state.weatherIcons = await response.json();
     }
 
-    clouds.forEach((cloud) => {
+    clouds.forEach((cloud, index) => {
       cloud.querySelectorAll(".surprise-heart").forEach((heart) => heart.remove());
-      cloud.style.backgroundImage = state.weatherIcons[weatherCode] ?? "url('assets/cloud.webp')";
+      const conditionArtwork = state.weatherIcons[weatherCode] ?? "url('assets/cloud.webp')";
+      cloud.style.backgroundImage = index % 3 === 2 ? "url('assets/cloud.webp')" : conditionArtwork;
       if (city === "Ho Chi Minh City") cloud.append(createHeart());
     });
   } catch (error) {
@@ -236,7 +266,7 @@ function renderWeather(city, weather) {
   renderForecast(weatherDays);
   renderHistory();
   temperatures.style.display = "flex";
-  void updateWeatherBackground(current.weatherCode, city);
+  void updateWeatherBackground(current.weatherCode, city, current.weatherDesc?.[0]?.value ?? "clear");
 }
 
 async function fetchWeather(city) {

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ const mainPage = document.querySelector(".mainPage");
 const form = document.querySelector("#weatherCity");
 const cityInput = document.querySelector("#city");
 const submitButton = document.querySelector("#weather_button");
+const motionToggle = document.querySelector("#motion-toggle");
 const cityInfo = document.querySelector("#cityInfo");
 const temperatures = document.querySelector("#temps");
 const emptyHistory = document.querySelector("#removed");
@@ -20,6 +21,8 @@ const state = {
   weatherByCity: new Map(),
   weatherIcons: null,
 };
+
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
 function normalizeCity(value) {
   return value
@@ -48,6 +51,24 @@ function setLoading(isLoading) {
   submitButton.disabled = isLoading;
   submitButton.textContent = isLoading ? "Loading..." : "Get Weather";
   form.setAttribute("aria-busy", String(isLoading));
+}
+
+function setMotionPaused(isPaused) {
+  document.body.classList.toggle("motion-paused", isPaused);
+  motionToggle.setAttribute("aria-pressed", String(isPaused));
+  motionToggle.textContent = isPaused ? "Play motion" : "Pause motion";
+}
+
+function applyMotionPreference(prefersReducedMotion) {
+  if (prefersReducedMotion) {
+    setMotionPaused(true);
+    motionToggle.textContent = "Motion reduced";
+    motionToggle.disabled = true;
+    return;
+  }
+
+  motionToggle.disabled = false;
+  setMotionPaused(false);
 }
 
 function showMessage(message) {
@@ -320,3 +341,10 @@ searchHistory.addEventListener("click", (event) => {
   const weather = state.weatherByCity.get(link.dataset.city);
   if (weather) renderWeather(link.dataset.city, weather);
 });
+
+motionToggle.addEventListener("click", () => {
+  setMotionPaused(!document.body.classList.contains("motion-paused"));
+});
+
+reducedMotion.addEventListener("change", (event) => applyMotionPreference(event.matches));
+applyMotionPreference(reducedMotion.matches);

--- a/main.js
+++ b/main.js
@@ -77,31 +77,40 @@ function renderCurrentConditions(city, area, current) {
   heading.append(headingText);
 
   const areaParagraph = createLabeledParagraph("Area:", area.areaName?.[0]?.value ?? "Unknown");
+  areaParagraph.className = "location-line";
   const regionParagraph = createLabeledParagraph(
     area.region?.[0]?.value ? "Region:" : "",
     area.region?.[0]?.value ?? "",
   );
+  regionParagraph.className = "location-line";
   const countryParagraph = createLabeledParagraph("", area.country?.[0]?.value ?? "");
+  countryParagraph.className = "location-line";
 
   const conditionParagraph = document.createElement("p");
+  conditionParagraph.className = "current-summary";
   const description = document.createElement("strong");
+  description.className = "current-condition";
   description.style.margin = "0";
   description.textContent = current.weatherDesc?.[0]?.value ?? "Conditions unavailable";
+
+  const temperatureGroup = document.createElement("span");
+  temperatureGroup.className = "current-reading";
   const feelsLike = document.createElement("strong");
+  feelsLike.className = "current-temperature";
   feelsLike.textContent = temperature(current[`FeelsLike${state.unit}`]);
+
+  const timeGroup = document.createElement("span");
+  timeGroup.className = "observed-reading";
   const observedAt = document.createElement("strong");
+  observedAt.className = "observed-time";
   observedAt.textContent = new Date().toLocaleTimeString("en-US", {
     hour: "2-digit",
     minute: "2-digit",
     hour12: true,
   });
-  conditionParagraph.append(
-    description,
-    document.createTextNode(" Feels like "),
-    feelsLike,
-    document.createTextNode(" at "),
-    observedAt,
-  );
+  temperatureGroup.append(document.createTextNode("Feels like "), feelsLike);
+  timeGroup.append(document.createTextNode("Observed "), observedAt);
+  conditionParagraph.append(description, temperatureGroup, timeGroup);
 
   const unitButton = document.createElement("button");
   unitButton.type = "button";

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ npm test
 - `main.js` owns application state, weather requests, rendering, unit conversion, and the session search history.
 - `style.css` preserves the original responsive visual system and animated weather layers.
 - `icons.json` maps weather codes to the original local background artwork.
-- `cypress/e2e/weather.cy.js` covers the main user journey, original panels and artwork, unit switching, cached history, and request failure.
+- `cypress/e2e/weather.cy.js` covers the main user journey, original panels and artwork, unit switching, cached history, request failure, motion controls, and desktop/mobile layout geometry.
 - `.github/workflows/quality.yml` runs install, build, and end-to-end verification on pushes and pull requests.
 
 ## Design decisions
@@ -57,6 +57,7 @@ npm test
 - Search history is intentionally session-only; the app does not collect accounts or personal data.
 - Weather responses are cached by normalized city name so toggling units and reopening a previous result do not make unnecessary API calls.
 - User-provided city names are rendered with `textContent`, not injected as HTML.
+- The animated sky uses the six original artwork layers plus condition-specific emoji accents. Users can pause the motion, and the app honors the system reduced-motion preference.
 
 ## Known limitations
 
@@ -75,6 +76,10 @@ The 2026 update:
 - removed duplicated rendering paths and unsafe user-input HTML;
 - preserved the original layout, animated weather artwork, Easter egg, and footer while adding non-visual accessibility metadata;
 - added tests that protect the original major panels and weather-art layers from accidental redesign;
+- repaired the phone layout and fixed-footer overlap while preserving the desktop composition;
+- improved text contrast and current-condition hierarchy within the original palette;
+- enriched the weather background with faster layered artwork and condition-specific emojis;
+- added pause/resume and reduced-motion behavior;
 - added a reproducible production build and GitHub Actions quality workflow.
 
 ## Original learning context

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ header {
     grid-template-columns: auto;
     padding: 5px;
     margin-bottom: 10px;
-    border: 1px solid rgb(240, 9, 28);
+    border: 1px solid #0d75bd;
     background-color: rgb(57, 193, 238);
 }
 
@@ -64,7 +64,7 @@ header {
     font-size: 1em;
     font-weight: bold;
     color: white;
-    background: linear-gradient(to bottom, #87ceeb, #1e90ff);
+    background: linear-gradient(to bottom, #0d75bd, #075985);
     box-shadow: 0 8px 15px rgba(0, 150, 255, 0.3);
     transition: all 0.3s ease;
     overflow: hidden;
@@ -73,7 +73,7 @@ header {
 
 .degreeCToF:hover, #weather_button:hover {
     transform: scale(1.05);
-    background: linear-gradient(to bottom, #1e90ff, #4682b4);
+    background: linear-gradient(to bottom, #075985, #064569);
     box-shadow: 0 12px 20px rgba(0, 150, 255, 0.4);
 }
 
@@ -180,7 +180,7 @@ header {
     justify-content: center;
     margin-top: 0px;
     margin-bottom: 10px;
-    color: #1e90ff;
+    color: #075985;
     font-size: 1.8em;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
@@ -201,7 +201,7 @@ header {
 }
 
 #cityInfo strong {
-    color: #1e90ff;
+    color: #075985;
     margin-right: 5px;
 }
 
@@ -234,7 +234,7 @@ header {
     width: 100%;
     padding: 15px;
     max-width: 200px;
-    color: white;
+    color: #17324d;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
     transition: transform 0.3s ease;
     background: linear-gradient(to bottom, #87ceeb, #1e90ff);
@@ -255,7 +255,7 @@ header {
     font-size: 1.2em;
     font-weight: bold;
     margin-bottom: 8px;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+    text-shadow: none;
 }
 
 .avg, .max, .min {
@@ -294,7 +294,7 @@ section {
 
 section h4 {
     margin-bottom: 10px;
-    color: #1e90ff;
+    color: #075985;
     font-size: 1.2em;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
@@ -334,7 +334,7 @@ section h4 {
 .previousCity {
     display: inline-flex;
     align-items: center;
-    color: #1e90ff;
+    color: #075985;
     font-weight: bold;
     text-decoration: none;
 }
@@ -356,8 +356,8 @@ section h4 {
     padding: 5px 0;
     color: white;
     box-sizing: border-box;
-    border-top: 2px solid #1e90ff;
-    background: linear-gradient(to right, #87ceeb, #1e90ff);
+    border-top: 2px solid #075985;
+    background: linear-gradient(to right, #0d75bd, #075985);
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
 }
 

--- a/style.css
+++ b/style.css
@@ -64,7 +64,7 @@ header {
 }
 
 /* Header Button styling */
-.degreeCToF, #weather_button {
+.degreeCToF, #weather_button, #motion-toggle {
     position: relative;
     display: inline-block;
     cursor: pointer;
@@ -82,10 +82,26 @@ header {
 }
 
 
-.degreeCToF:hover, #weather_button:hover {
+.degreeCToF:hover, #weather_button:hover, #motion-toggle:hover {
     transform: scale(1.05);
     background: linear-gradient(to bottom, #075985, #064569);
     box-shadow: 0 12px 20px rgba(0, 150, 255, 0.4);
+}
+
+#motion-toggle {
+    color: #075985;
+    background: linear-gradient(to bottom, #f0f9ff, #b3e5fc);
+}
+
+#motion-toggle:hover {
+    color: white;
+}
+
+#motion-toggle:disabled {
+    cursor: not-allowed;
+    color: #334155;
+    opacity: 0.8;
+    transform: none;
 }
 
 #weather_button::before {
@@ -176,6 +192,27 @@ header {
     0% { transform: translate3d(-10vw, 8px, 0) rotate(-4deg); }
     50% { transform: translate3d(70vw, -10px, 0) rotate(3deg); }
     100% { transform: translate3d(130vw, 6px, 0) rotate(-2deg); }
+}
+
+body.motion-paused .cloud,
+body.motion-paused .weather-emoji {
+    animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .cloud,
+    .weather-emoji {
+        animation: none;
+    }
+
+    .tempertures,
+    .degreeCToF,
+    #weather_button,
+    #motion-toggle,
+    #list li,
+    .footer-link {
+        transition: none;
+    }
 }
 
 

--- a/style.css
+++ b/style.css
@@ -7,6 +7,17 @@ body, html {
 
 }
 
+body {
+    position: relative;
+    min-height: 100vh;
+}
+
+header,
+.mainPage,
+.weather-footer {
+    z-index: 1;
+}
+
 /* ------------------------ Header ------------------------ */
 header {
     display: grid;
@@ -108,13 +119,14 @@ header {
  /* ------------------------ Cloud styling ------------------------ */
 /* Cloud container styling */
 .cloud-container {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: 100vh;
     overflow: hidden;
     pointer-events: none;
+    z-index: 0;
 }
 
 /* Basic cloud styling with background image */
@@ -128,20 +140,42 @@ header {
     overflow: visible;
     opacity: 0.8;
     animation: float linear infinite;
+    will-change: transform;
 }
 
 /* Cloud variations */
-.cloud:nth-child(1) { width: 250px; height: 130px; top: 30%; left: -350px; animation-duration: 50s; }
-.cloud:nth-child(2) { width: 250px; height: 130px; top: 30%; left: -350px; animation-duration: 50s; }
-.cloud:nth-child(3) { width: 200px; height: 110px; top: 60%; left: 0px; animation-duration: 60s; }
-.cloud:nth-child(4) { width: 220px; height: 120px; top: 75%; left: -400px; animation-duration: 70s; }
-.cloud:nth-child(5) { width: 280px; height: 140px; top: 20%; left: -300px; animation-duration: 65s; }
-.cloud:nth-child(6) { width: 320px; height: 160px; top: 50%; left: -450px; animation-duration: 55s; }
+.cloud:nth-child(1) { width: 250px; height: 130px; top: 18%; left: -350px; animation-duration: 28s; animation-delay: -8s; }
+.cloud:nth-child(2) { width: 180px; height: 95px; top: 34%; left: -300px; animation-duration: 34s; animation-delay: -24s; }
+.cloud:nth-child(3) { width: 200px; height: 110px; top: 58%; left: -250px; animation-duration: 38s; animation-delay: -14s; }
+.cloud:nth-child(4) { width: 220px; height: 120px; top: 76%; left: -400px; animation-duration: 44s; animation-delay: -34s; }
+.cloud:nth-child(5) { width: 280px; height: 140px; top: 8%; left: -300px; animation-duration: 50s; animation-delay: -42s; }
+.cloud:nth-child(6) { width: 320px; height: 160px; top: 46%; left: -450px; animation-duration: 58s; animation-delay: -20s; }
+
+.weather-emoji {
+    position: absolute;
+    left: -15vw;
+    opacity: 0.62;
+    filter: drop-shadow(0 6px 10px rgba(7, 89, 133, 0.18));
+    animation: weather-drift 32s linear infinite;
+    will-change: transform;
+}
+
+.weather-emoji:nth-of-type(1) { top: 14%; font-size: 2.6rem; animation-duration: 22s; animation-delay: -12s; }
+.weather-emoji:nth-of-type(2) { top: 32%; font-size: 1.9rem; animation-duration: 27s; animation-delay: -23s; }
+.weather-emoji:nth-of-type(3) { top: 52%; font-size: 3rem; animation-duration: 31s; animation-delay: -6s; }
+.weather-emoji:nth-of-type(4) { top: 70%; font-size: 2.1rem; animation-duration: 35s; animation-delay: -29s; }
+.weather-emoji:nth-of-type(5) { top: 84%; font-size: 2.5rem; animation-duration: 39s; animation-delay: -18s; }
 
 /* Floating animation */
 @keyframes float {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(150vw); }
+    0% { transform: translate3d(-100%, 0, 0); }
+    100% { transform: translate3d(150vw, 0, 0); }
+}
+
+@keyframes weather-drift {
+    0% { transform: translate3d(-10vw, 8px, 0) rotate(-4deg); }
+    50% { transform: translate3d(70vw, -10px, 0) rotate(3deg); }
+    100% { transform: translate3d(130vw, 6px, 0) rotate(-2deg); }
 }
 
 
@@ -527,6 +561,13 @@ section h4 {
     #cityInfo .current-summary::before,
     #cityInfo .current-condition {
         grid-column: 1;
+    }
+
+    .cloud:nth-child(5),
+    .cloud:nth-child(6),
+    .weather-emoji:nth-of-type(4),
+    .weather-emoji:nth-of-type(5) {
+        display: none;
     }
 
     #temps {

--- a/style.css
+++ b/style.css
@@ -164,7 +164,7 @@ header {
     overflow: hidden;
     margin: 20px auto;
     padding: 20px;
-    max-width: 320px;
+    max-width: 420px;
     color: #333;
     text-align: center;
     border: 2px solid teal;
@@ -213,6 +213,54 @@ header {
 #cityInfo p:nth-child(2)::before { content: '📍'; }
 #cityInfo p:nth-child(4)::before { content: '🌎'; }
 #cityInfo p:nth-child(5)::before { content: '🌡️'; }
+
+#cityInfo .location-line {
+    line-height: 1.4;
+}
+
+#cityInfo .current-summary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 12px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(7, 89, 133, 0.25);
+}
+
+#cityInfo .current-summary::before,
+#cityInfo .current-condition {
+    grid-column: 1 / -1;
+}
+
+#cityInfo .current-summary::before {
+    margin: 0 auto;
+}
+
+#cityInfo .current-condition {
+    font-size: 1.15em;
+}
+
+#cityInfo .current-reading,
+#cityInfo .observed-reading {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 4px;
+}
+
+#cityInfo .current-temperature {
+    margin: 0;
+    font-size: 1.3em;
+}
+
+#cityInfo .observed-time {
+    margin: 0;
+    color: #334155;
+}
+
+#cityInfo .degreeCToF {
+    margin-top: 10px;
+}
 
 /* ------------------------ Temperature styling ------------------------ */
 #temps {
@@ -470,6 +518,15 @@ section h4 {
     #cityInfo {
         width: calc(100% - 20px);
         box-sizing: border-box;
+    }
+
+    #cityInfo .current-summary {
+        grid-template-columns: 1fr;
+    }
+
+    #cityInfo .current-summary::before,
+    #cityInfo .current-condition {
+        grid-column: 1;
     }
 
     #temps {

--- a/style.css
+++ b/style.css
@@ -396,8 +396,34 @@ section h4 {
 
 /* ------------------------ Media Queries ------------------------ */
 @media (max-width: 768px) {
+    body, html {
+        overflow-x: hidden;
+    }
+
+    .mainPage {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 10px;
+        width: 100%;
+        padding-bottom: 20px;
+    }
+
+    .mainPage > aside:first-child {
+        display: none;
+    }
+
+    .mainBoxes,
+    .mainPage > aside:last-child {
+        min-width: 0;
+        width: 100%;
+    }
+
+    section {
+        box-sizing: border-box;
+    }
+
     #temps {
         gap: 10px;
+        box-sizing: border-box;
     }
 
     .tempertures {
@@ -413,9 +439,39 @@ section h4 {
     .avg, .max, .min {
         font-size: 0.85em;
     }
+
+    .weather-footer {
+        position: static;
+        width: calc(100% + 20px);
+        margin-left: -10px;
+    }
 }
 
 @media (max-width: 480px) {
+    header {
+        box-sizing: border-box;
+    }
+
+    #weatherCity {
+        flex-direction: column;
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    #city {
+        width: min(250px, 100%);
+        box-sizing: border-box;
+    }
+
+    #weather_button {
+        margin-left: 0;
+    }
+
+    #cityInfo {
+        width: calc(100% - 20px);
+        box-sizing: border-box;
+    }
+
     #temps {
         gap: 8px;
         padding: 5px;


### PR DESCRIPTION
## Summary

This pull request improves the Weather App's existing interface without replacing its original visual identity.

- repairs the small-screen layout and prevents footer overlap
- improves text and control contrast while retaining the original palette
- clarifies the current-condition hierarchy inside the existing weather card
- enriches the six original animated weather layers with varied timing and condition-specific emoji accents
- adds pause/resume and reduced-motion support
- expands Cypress regression coverage for desktop, phone, motion, and weather artwork
- documents the approved UI decisions and constraints

## Preserved intentionally

- original header and three-column composition
- current-weather and three-day forecast panels
- previous-search panel
- six weather-art layers and `icons.json` imagery
- existing gradients, rounded controls, footer, and Ho Chi Minh City Easter egg
- vanilla JavaScript architecture and wttr.in integration

## Verification

- `npm run build`
- seven Cypress tests against a dedicated Vite server on port 5183
- technical-modernization `Quality` and GitHub Pages workflows on `main`

## Review gate

This is a draft. It should not be merged until Dennis reviews and approves the updated interface.